### PR TITLE
RIS lane id fix

### DIFF
--- a/TLCGen.PluggedInItems/TLCGen.Plugins.RIS/RISPlugin.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Plugins.RIS/RISPlugin.cs
@@ -351,9 +351,10 @@ namespace TLCGen.Plugins.RIS
                     sb.AppendLine();
                     sb.AppendLine($"/* Definitie lane id in het topologiebestand */");
                     sb.AppendLine($"/* ----------------------------------------- */");
+                    sb.AppendLine($"#define ris_conflict_gebied    0 /* connection tussen alle ingress lanes en egress lanes */");
                     foreach (var l in lanes)
                     {
-                        sb.AppendLine($"#define ris_lane{l.SignalGroupName}{l.RijstrookIndex} {l.LaneID} /* lane ID van richting {l.SignalGroupName} van strook {l.RijstrookIndex + 1} */");
+                        sb.AppendLine($"#define ris_lane{l.SignalGroupName}{l.RijstrookIndex}          {l.LaneID,3} /* lane ID van richting {l.SignalGroupName} van strook {l.RijstrookIndex} */");
                     }
                     sb.AppendLine();
                     return sb.ToString();

--- a/TLCGen.PluggedInItems/TLCGen.Plugins.RIS/ViewModels/RISTabViewModel.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Plugins.RIS/ViewModels/RISTabViewModel.cs
@@ -111,7 +111,7 @@ namespace TLCGen.Plugins.RIS
                 UpdateRISLanes();
                 for (int l = 0; l < RISLanes.Count; l++)
                 {
-                    RISLanes[l].LaneID = l;
+                    RISLanes[l].LaneID = l + 1;
                 }
             }
         }


### PR DESCRIPTION
Fix voor ris lane id 0. Die is voor de conflictgebieden tussen ingress lanes en egress lanes. De normale lane id's beginnen te tellen bij 1.