### PR TITLE
Peloton koppeling fix SpecGenerator + mogelijkheid in specgen voor input vanuit gebruikers plugin

### DIFF
--- a/TLCGen.PluggedInItems/TLCGen.Specificator/SpecificationGenerator.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Specificator/SpecificationGenerator.cs
@@ -46,6 +46,8 @@ namespace TLCGen.Specificator
 
             foreach (var specData in pluginData.Where(x => (x.Subject == SpecificationSubject.DynHiaat)
                                                         || (x.Subject == SpecificationSubject.AFM)
+                                                        || (x.Subject == SpecificationSubject.GebruikersPlugin1)
+                                                        || (x.Subject == SpecificationSubject.GebruikersPlugin2)
                                                         ))
             {
                 // verwerken spec data uit plugins
@@ -215,6 +217,11 @@ namespace TLCGen.Specificator
                     body.Append(FunctionalityGenerator.GetChapter_TT_UC4_Informeren(c, doc));
                     body.Append(FunctionalityGenerator.GetChapter_TT_UC5_Optimaliseren(c));
                 }
+
+                // Chaps gebruikers plugins
+                AppendGenericSpecificationData(doc, pluginData.Where(x => x.Subject == SpecificationSubject.GebruikersPlugin1));
+
+                AppendGenericSpecificationData(doc, pluginData.Where(x => x.Subject == SpecificationSubject.GebruikersPlugin2));
 
                 //ToDo: - OV nadere details (conditionele prio, inmelden koplus, prio nivo, inmelden/aanvragen koplus,
                 //                           check wagennummer, anti-jutter, klokperiode als voorwaarde, rit categorie).

--- a/TLCGen.PluggedInItems/TLCGen.Specificator/TableGenerator.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Specificator/TableGenerator.cs
@@ -2559,8 +2559,8 @@ namespace TLCGen.Specificator
                     fi.Naam,
                     fi.FileMetingLocatie.GetDescription(),
                     fi.AanUit.ToCustomString2(),
-                    fi.MetingPerLus ? fi.MetingPerLus.ToCustomString() : "-",
-                    fi.MetingPerStrook ? fi.MetingPerStrook.ToCustomString() : "-",
+                    fi.MetingPerLus.ToCustomStringJN(),
+                    fi.MetingPerStrook.ToCustomStringJN(),
                     fi.AfvalVertraging.ToString(),
                     fi.EerlijkDoseren ? fi.EerlijkDoseren.ToCustomString() : "-",
                     fi.ToepassenDoseren.GetDescription(),
@@ -3067,19 +3067,18 @@ namespace TLCGen.Specificator
                 l.Add(new List<string>
                 {
                     kopp.KoppelingNaam.ToString(),
-                    kopp.PTPKruising.ToString(),
+                    kopp.IsIntern ? "-" : kopp.PTPKruising.ToString(),
                     kopp.Richting.ToString(),
                     kopp.GekoppeldeSignaalGroep.ToString(),
                     kopp.Type.GetDescription(),
                     kopp.IsIntern.ToCustomString(),
-                    kopp.IsIntern ? kopp.GerelateerdePelotonKoppeling.ToString() : "-"
-
+                    kopp.IsIntern && (kopp.Richting == PelotonKoppelingRichtingEnum.Inkomend) ? kopp.GerelateerdePelotonKoppeling.ToString() : "-"
                  });
             }
             items.Add(OpenXmlHelper.GetTable(l, firstRowVerticalText: true));
 
             items.Add(OpenXmlHelper.GetTextParagraph("", "Footer"));
-
+           
             if (c.PelotonKoppelingenData.PelotonKoppelingen.Any(x => x.Type == Models.Enumerations.PelotonKoppelingTypeEnum.DenHaag))
             {
                 UpdateTables("Table_Pelotonkoppelingen_Inkomend_DenHaag");
@@ -3139,11 +3138,10 @@ namespace TLCGen.Specificator
                     {
                         "Naam (###)",
                         "Fase",
-                        "Verschuiving                 PRM " + CCOLGeneratorSettingsProvider.Default.GetElementName("prmpelverschuif") + "###",
-                        "Min. duur peloton            ",
-                        "Min. aantal mvt              PRM " + CCOLGeneratorSettingsProvider.Default.GetElementName("prmpelgrens") + "###",
+                        "Verschuiving [s]             PRM " + CCOLGeneratorSettingsProvider.Default.GetElementName("prmpelverschuif") + "###",
+                        "Min. duur peloton [s]        PRM " + CCOLGeneratorSettingsProvider.Default.GetElementName("prmpelgrens") + "###",
                         "Toepassen RW                 SCH " + CCOLGeneratorSettingsProvider.Default.GetElementName("schpelrw") + "###",
-                        "Nalooptijd                   T " + CCOLGeneratorSettingsProvider.Default.GetElementName("tpelnl") + "###",
+                        "Nalooptijd [s]               T " + CCOLGeneratorSettingsProvider.Default.GetElementName("tpelnl") + "###",
                         "Toepassen A                  SCH " + CCOLGeneratorSettingsProvider.Default.GetElementName("schpela") + "###",
                         "Toepassen MK                 SCH " + CCOLGeneratorSettingsProvider.Default.GetElementName("schpelmk") + "###",
                     }
@@ -3155,7 +3153,6 @@ namespace TLCGen.Specificator
                         koppi.KoppelingNaam.ToString(),
                         koppi.GekoppeldeSignaalGroep.ToString(),
                         koppi.Verschuiving.ToString(),
-                        koppi.Meetperiode.ToString(),
                         koppi.MinimaalAantalVoertuigen.ToString(),
                         koppi.ToepassenRetourWachtgroen.GetDescription(),
                         koppi.TijdRetourWachtgroen.ToString(),
@@ -3200,7 +3197,7 @@ namespace TLCGen.Specificator
 
                 items.Add(OpenXmlHelper.GetTextParagraph("", "Footer"));
             }
-
+            
             return items;
         }
 


### PR DESCRIPTION
Bij het toepassen van een interne pelotonkoppeling bleek dat dit een fout (nullreference bij de uitgaande koppeling) opleverde in de specificatie generator. Dat wordt hiermee hersteld. Ik heb meteen van de gelegenheid gebruik gemaakt om de mogelijkheid voor 2 gebruikers-plugin-hoofdstukken toe te voegen. Die waren al opgenomen in de betreffende enumeratie maar tot op heden nog niet uitgewerkt.