### PR TITLE
Optioneel toevoegen ingreepnaam aan file detectorelementen + fix eerlijk doseren icm TVGAmax

### DIFF
--- a/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepDetectorModel.cs
+++ b/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepDetectorModel.cs
@@ -13,5 +13,6 @@ namespace TLCGen.Models
         public int BezetTijd { get; set; }
         public int RijTijd { get; set; }
         public int AfvalVertraging { get; set; }
+        public bool IngreepNaamPerLus { get; set; }
     }
 }

--- a/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepModel.cs
+++ b/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepModel.cs
@@ -24,6 +24,8 @@ namespace TLCGen.Models
         public bool MetingPerStrook { get; set; }
         public int AfvalVertraging { get; set; }
         [HasDefault(false)]
+        public bool IngreepNaamPerLus { get; set; }
+        [HasDefault(false)]
         public bool EerlijkDoseren { get; set; }
         [HasDefault(false)]
         public NooitAltijdAanUitEnum ToepassenDoseren { get; set; }

--- a/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepModel.cs
+++ b/TLCGen.Dependencies/TLCGen.Dependencies/Models/Models/FileIngreep/FileIngreepModel.cs
@@ -24,8 +24,6 @@ namespace TLCGen.Models
         public bool MetingPerStrook { get; set; }
         public int AfvalVertraging { get; set; }
         [HasDefault(false)]
-        public bool IngreepNaamPerLus { get; set; }
-        [HasDefault(false)]
         public bool EerlijkDoseren { get; set; }
         [HasDefault(false)]
         public NooitAltijdAanUitEnum ToepassenDoseren { get; set; }

--- a/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/FileIngrepenCodeGenerator.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/FileIngrepenCodeGenerator.cs
@@ -136,28 +136,56 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                 }
                 foreach (var fd in fm.FileDetectoren)
                 {
-                    _myElements.Add(
-                        CCOLGeneratorSettingsProvider.Default.CreateElement(
-                            $"{_tafv}{fd.Detector}",
-                            fd.AfvalVertraging,
-                            CCOLElementTimeTypeEnum.TE_type,
-                            _tafv, fd.Detector));
-                    _myElements.Add(
-                        CCOLGeneratorSettingsProvider.Default.CreateElement(
-                            $"{_tbz}{fd.Detector}",
-                            fd.BezetTijd,
-                            CCOLElementTimeTypeEnum.TE_type,
-                            _tbz, fd.Detector));
-                    _myElements.Add(
-                        CCOLGeneratorSettingsProvider.Default.CreateElement(
-                            $"{_trij}{fd.Detector}",
-                            fd.RijTijd,
-                            CCOLElementTimeTypeEnum.TE_type,
-                            _trij, fd.Detector));
-                    _myElements.Add(
-                        CCOLGeneratorSettingsProvider.Default.CreateElement(
-                            $"{_hfile}{fd.Detector}",
-                            _hfile, fd.Detector));
+                    if (fd.IngreepNaamPerLus)
+                    {
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_tafv}{fd.Detector}_{fm.Naam}",
+                                fd.AfvalVertraging,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _tafv, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_tbz}{fd.Detector}_{fm.Naam}",
+                                fd.BezetTijd,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _tbz, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_trij}{fd.Detector}_{fm.Naam}",
+                                fd.RijTijd,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _trij, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_hfile}{fd.Detector}_{fm.Naam}",
+                                _hfile, fd.Detector));
+                    }
+                    else
+                    {
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_tafv}{fd.Detector}",
+                                fd.AfvalVertraging,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _tafv, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_tbz}{fd.Detector}",
+                                fd.BezetTijd,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _tbz, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_trij}{fd.Detector}",
+                                fd.RijTijd,
+                                CCOLElementTimeTypeEnum.TE_type,
+                                _trij, fd.Detector));
+                        _myElements.Add(
+                            CCOLGeneratorSettingsProvider.Default.CreateElement(
+                                $"{_hfile}{fd.Detector}",
+                                _hfile, fd.Detector));
+                    }
                 }
                 if (fm.EerlijkDoseren && fm.TeDoserenSignaalGroepen.Count > 0)
                 {
@@ -366,18 +394,19 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             foreach (var fc in fi.TeDoserenSignaalGroepen)
                             {
                                 sb.Append($"{ts}");
-                                var defmg = c.GroentijdenSets.FirstOrDefault(
-                                    x => x.Naam == c.PeriodenData.DefaultPeriodeGroentijdenSet);
-                                var defmgfc = defmg?.Groentijden.FirstOrDefault(x => x.FaseCyclus == fc.FaseCyclus);
-                                if (defmgfc?.Waarde != null)
+                                if (!c.Data.TVGAMaxAlsDefaultGroentijdSet)
                                 {
-                                    sb.Append($"filefc{gtt}_{fi.Naam}[{i}][0] = {_prmpf}{c.PeriodenData.DefaultPeriodeGroentijdenSet.ToLower()}_{fc.FaseCyclus};");
+                                    var defmg = c.GroentijdenSets.FirstOrDefault(
+                                    x => x.Naam == c.PeriodenData.DefaultPeriodeGroentijdenSet);
+                                    var defmgfc = defmg?.Groentijden.FirstOrDefault(x => x.FaseCyclus == fc.FaseCyclus);
+                                    if (defmgfc?.Waarde != null)
+                                    {
+                                        sb.Append($"filefc{gtt}_{fi.Naam}[{i}][0] = {_prmpf}{c.PeriodenData.DefaultPeriodeGroentijdenSet.ToLower()}_{fc.FaseCyclus};");
+                                    }
                                 }
                                 var j = 1;
                                 foreach (var per in c.PeriodenData.Perioden)
                                 {
-
-                                
                                     if (per.Type == PeriodeTypeEnum.Groentijden)
                                     {
                                         foreach (var mgsm in c.GroentijdenSets)
@@ -388,7 +417,7 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                                 {
                                                     if (mgm.FaseCyclus == fc.FaseCyclus && mgm.Waarde.HasValue)
                                                     {
-                                                        sb.Append($" filefc{gtt}_{fi.Naam}[{i}][{j}] = {_prmpf}{mgsm.Naam.ToLower()}_{fc.FaseCyclus};");
+                                                        sb.Append($"filefc{gtt}_{fi.Naam}[{i}][{j}] = {_prmpf}{mgsm.Naam.ToLower()}_{fc.FaseCyclus};");
                                                     }
                                                 }
                                             }
@@ -481,9 +510,13 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                         sb.AppendLine($"{ts}/* File ingreep {fm.Naam} */");
                         sb.AppendLine();
 
+                        //string tbz, trij, tafv, hfile;
                         foreach (var fd in fm.FileDetectoren)
                         {
-                            sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{fd.Detector}, {_tpf}{_trij}{fd.Detector}, {_tpf}{_tafv}{fd.Detector}, {_hpf}{_hfile}{fd.Detector});");
+                            if (fd.IngreepNaamPerLus)
+                                sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{fd.Detector}_{fm.Naam}, {_tpf}{_trij}{fd.Detector}_{fm.Naam}, {_tpf}{_tafv}{fd.Detector}_{fm.Naam}, {_hpf}{_hfile}{fd.Detector}_{fm.Naam});");
+                            else
+                                sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{fd.Detector}, {_tpf}{_trij}{fd.Detector}, {_tpf}{_tafv}{fd.Detector}, {_hpf}{_hfile}{fd.Detector});");
                         }
 
                         sb.Append($"{ts}RT[{_tpf}{_tafv}{fm.Naam}] = ");
@@ -503,7 +536,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                         sb.AppendLine($"{ts}{{");
                         foreach (var fd in fm.FileDetectoren)
                         {
-                            sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{fd.Detector}] = FALSE;");
+                            if (fd.IngreepNaamPerLus)
+                                sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}] = FALSE;");
+                            else
+                                sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{fd.Detector}] = FALSE;");
                         }
                         sb.AppendLine($"{ts}}}");
                         
@@ -540,7 +576,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 {
                                     if (id > 0) sb.Append(" || ");
                                     ++id;
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    if (fd.IngreepNaamPerLus)
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                    else
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}{ts}}}");
@@ -598,7 +637,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 {
                                     if (id > 0) sb.Append(" && ");
                                     ++id;
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    if (fd.IngreepNaamPerLus)
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                    else
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}{ts}}}");
@@ -615,7 +657,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 {
                                     if (id > 0) sb.Append(" || ");
                                     ++id;
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    if (fd.IngreepNaamPerLus)
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                    else
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}}}");
@@ -628,7 +673,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 {
                                     if (id > 0) sb.Append(" && ");
                                     ++id;
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    if (fd.IngreepNaamPerLus)
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                    else
+                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}}}");
@@ -645,7 +693,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             {
                                 if (id > 0) sb.Append(" || ");
                                 ++id;
-                                sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                if (fd.IngreepNaamPerLus)
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                else
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                             }
                             sb.AppendLine(";");
                             sb.AppendLine($"{ts}}}");
@@ -658,7 +709,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             {
                                 if (id > 0) sb.Append(" && ");
                                 ++id;
-                                sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                if (fd.IngreepNaamPerLus)
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                else
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                             }
                             sb.AppendLine($";");
                             sb.AppendLine($"{ts}}}");
@@ -673,7 +727,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 {
                                     sb.Append(" || ");
                                 }
-                                sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                if (fd.IngreepNaamPerLus)
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
+                                else
+                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
                                 ++i;
                             }
                             sb.AppendLine($";");

--- a/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/FileIngrepenCodeGenerator.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/FileIngrepenCodeGenerator.cs
@@ -136,56 +136,29 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                 }
                 foreach (var fd in fm.FileDetectoren)
                 {
-                    if (fd.IngreepNaamPerLus)
-                    {
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_tafv}{fd.Detector}_{fm.Naam}",
-                                fd.AfvalVertraging,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _tafv, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_tbz}{fd.Detector}_{fm.Naam}",
-                                fd.BezetTijd,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _tbz, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_trij}{fd.Detector}_{fm.Naam}",
-                                fd.RijTijd,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _trij, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_hfile}{fd.Detector}_{fm.Naam}",
-                                _hfile, fd.Detector));
-                    }
-                    else
-                    {
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_tafv}{fd.Detector}",
-                                fd.AfvalVertraging,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _tafv, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_tbz}{fd.Detector}",
-                                fd.BezetTijd,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _tbz, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_trij}{fd.Detector}",
-                                fd.RijTijd,
-                                CCOLElementTimeTypeEnum.TE_type,
-                                _trij, fd.Detector));
-                        _myElements.Add(
-                            CCOLGeneratorSettingsProvider.Default.CreateElement(
-                                $"{_hfile}{fd.Detector}",
-                                _hfile, fd.Detector));
-                    }
+                    var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
+                    _myElements.Add(
+                        CCOLGeneratorSettingsProvider.Default.CreateElement(
+                            $"{_tafv}{elemNameDet}",
+                            fd.AfvalVertraging,
+                            CCOLElementTimeTypeEnum.TE_type,
+                            _tafv, fd.Detector));
+                    _myElements.Add(
+                        CCOLGeneratorSettingsProvider.Default.CreateElement(
+                            $"{_tbz}{elemNameDet}",
+                            fd.BezetTijd,
+                            CCOLElementTimeTypeEnum.TE_type,
+                            _tbz, fd.Detector));
+                    _myElements.Add(
+                        CCOLGeneratorSettingsProvider.Default.CreateElement(
+                            $"{_trij}{elemNameDet}",
+                            fd.RijTijd,
+                            CCOLElementTimeTypeEnum.TE_type,
+                            _trij, fd.Detector));
+                    _myElements.Add(
+                        CCOLGeneratorSettingsProvider.Default.CreateElement(
+                            $"{_hfile}{elemNameDet}",
+                            _hfile, fd.Detector));
                 }
                 if (fm.EerlijkDoseren && fm.TeDoserenSignaalGroepen.Count > 0)
                 {
@@ -510,13 +483,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                         sb.AppendLine($"{ts}/* File ingreep {fm.Naam} */");
                         sb.AppendLine();
 
-                        //string tbz, trij, tafv, hfile;
                         foreach (var fd in fm.FileDetectoren)
                         {
-                            if (fd.IngreepNaamPerLus)
-                                sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{fd.Detector}_{fm.Naam}, {_tpf}{_trij}{fd.Detector}_{fm.Naam}, {_tpf}{_tafv}{fd.Detector}_{fm.Naam}, {_hpf}{_hfile}{fd.Detector}_{fm.Naam});");
-                            else
-                                sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{fd.Detector}, {_tpf}{_trij}{fd.Detector}, {_tpf}{_tafv}{fd.Detector}, {_hpf}{_hfile}{fd.Detector});");
+                            var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
+                            sb.AppendLine($"{ts}FileMeldingV2({_dpf}{fd.Detector}, {_tpf}{_tbz}{elemNameDet}, {_tpf}{_trij}{elemNameDet}, {_tpf}{_tafv}{elemNameDet}, {_hpf}{_hfile}{elemNameDet});");
                         }
 
                         sb.Append($"{ts}RT[{_tpf}{_tafv}{fm.Naam}] = ");
@@ -536,10 +506,8 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                         sb.AppendLine($"{ts}{{");
                         foreach (var fd in fm.FileDetectoren)
                         {
-                            if (fd.IngreepNaamPerLus)
-                                sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}] = FALSE;");
-                            else
-                                sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{fd.Detector}] = FALSE;");
+                            var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
+                            sb.AppendLine($"{ts}{ts}IH[{_hpf}{_hfile}{elemNameDet}] = FALSE;");
                         }
                         sb.AppendLine($"{ts}}}");
                         
@@ -574,12 +542,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 var id = 0;
                                 foreach (var fd in fm.FileDetectoren)
                                 {
+                                    var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                     if (id > 0) sb.Append(" || ");
                                     ++id;
-                                    if (fd.IngreepNaamPerLus)
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                    else
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}{ts}}}");
@@ -635,12 +601,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 id = 0;
                                 foreach (var fd in fm.FileDetectoren)
                                 {
+                                    var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                     if (id > 0) sb.Append(" && ");
                                     ++id;
-                                    if (fd.IngreepNaamPerLus)
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                    else
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}{ts}}}");
@@ -655,12 +619,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 var id = 0;
                                 foreach (var fd in fm.FileDetectoren)
                                 {
+                                    var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                     if (id > 0) sb.Append(" || ");
                                     ++id;
-                                    if (fd.IngreepNaamPerLus)
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                    else
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}}}");
@@ -671,12 +633,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                                 id = 0;
                                 foreach (var fd in fm.FileDetectoren)
                                 {
+                                    var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                     if (id > 0) sb.Append(" && ");
                                     ++id;
-                                    if (fd.IngreepNaamPerLus)
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                    else
-                                        sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                    sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                                 }
                                 sb.AppendLine($";");
                                 sb.AppendLine($"{ts}}}");
@@ -691,12 +651,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             var id = 0;
                             foreach (var fd in fm.FileDetectoren)
                             {
+                                var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                 if (id > 0) sb.Append(" || ");
                                 ++id;
-                                if (fd.IngreepNaamPerLus)
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                else
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                             }
                             sb.AppendLine(";");
                             sb.AppendLine($"{ts}}}");
@@ -707,12 +665,10 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             id = 0;
                             foreach (var fd in fm.FileDetectoren)
                             {
+                                var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                 if (id > 0) sb.Append(" && ");
                                 ++id;
-                                if (fd.IngreepNaamPerLus)
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                else
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                             }
                             sb.AppendLine($";");
                             sb.AppendLine($"{ts}}}");
@@ -723,14 +679,12 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                             i = 0;
                             foreach (var fd in fm.FileDetectoren)
                             {
+                                var elemNameDet = fd.IngreepNaamPerLus ? $"{fd.Detector}_i{fm.Naam}" : $"{fd.Detector}";
                                 if (i != 0)
                                 {
                                     sb.Append(" || ");
                                 }
-                                if (fd.IngreepNaamPerLus)
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}_{fm.Naam}]");
-                                else
-                                    sb.Append($"IH[{_hpf}{_hfile}{fd.Detector}]");
+                                sb.Append($"IH[{_hpf}{_hfile}{elemNameDet}]");
                                 ++i;
                             }
                             sb.AppendLine($";");

--- a/TLCGen/Views/Tabs/SpecialsTab/DataTypes/FileIngreepDetectorViewModel.cs
+++ b/TLCGen/Views/Tabs/SpecialsTab/DataTypes/FileIngreepDetectorViewModel.cs
@@ -54,6 +54,16 @@ namespace TLCGen.ViewModels
             }
         }
 
+        public bool IngreepNaamPerLus
+        {
+            get => _Detector.IngreepNaamPerLus;
+            set
+            {
+                _Detector.IngreepNaamPerLus = value;
+                OnPropertyChanged(nameof(IngreepNaamPerLus), broadcast: true);
+            }
+        }
+
         #endregion // Properties
 
         #region Private methods

--- a/TLCGen/Views/Tabs/SpecialsTab/DataTypes/FileIngreepView.xaml
+++ b/TLCGen/Views/Tabs/SpecialsTab/DataTypes/FileIngreepView.xaml
@@ -86,6 +86,22 @@
                     <DataGridTextColumn Binding="{Binding Path=BezetTijd}" Header="Bezettijd" />
                     <DataGridTextColumn Binding="{Binding Path=RijTijd}" Header="Rijtijd" />
                     <DataGridTextColumn Binding="{Binding Path=AfvalVertraging}" Header="Afval vertraging" />
+
+                    <DataGridCheckBoxColumn Binding="{Binding Path=IngreepNaamPerLus,UpdateSourceTrigger=PropertyChanged}" Width="100">
+                        <DataGridCheckBoxColumn.Header>
+                            <DockPanel>
+                                <TextBlock Text="Ingreepnaam "  DockPanel.Dock="Left" />
+                                <ct:InfoElement DockPanel.Dock="Right">
+                                    <ct:InfoElement.InfoPopup>
+                                        <TextBlock>
+                                            Door toevoegen van de naam van de file ingreep kan<LineBreak />
+                                            dezelfde lus bij meerdere ingrepen gebruikt worden.
+                                        </TextBlock>
+                                    </ct:InfoElement.InfoPopup>
+                                </ct:InfoElement>
+                            </DockPanel>
+                        </DataGridCheckBoxColumn.Header>
+                    </DataGridCheckBoxColumn>
                 </DataGrid.Columns>
             </DataGrid>
         </DockPanel>


### PR DESCRIPTION
Mogelijkheid om optioneel de naam van de file ingreep toe te voegen aan de te genereren file detector elementen (issue #146), plus fix voor eerlijk doseren icm toepassing van TVGAmax (issue #118). 