### PR TITLE
Fix: wachtlicht kon uit blijven bij afvallen schoolingreep

### DIFF
--- a/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/SchoolIngreepCodeGenerator.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Functionality/SchoolIngreepCodeGenerator.cs
@@ -153,7 +153,7 @@ namespace TLCGen.Generators.CCOL.CodeGeneration.Functionality
                         {
                             sb.Append($"{ts}if (SCH[{_schpf}{_schschoolingreep}{d.Item1.Naam}]) ");
                         }
-                        sb.AppendLine($"CIF_GUS[{_uspf}{_uswt}{d.Item2.Naam}] = CIF_GUS[{_uspf}{_uswt}{d.Item2.Naam}] && !(IH[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] && Knipper_1Hz) || G[{_fcpf}{d.Item1.Naam}] && D[{_dpf}{d.Item2.Naam}] && IH[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] && Knipper_1Hz;");
+                        sb.AppendLine($"CIF_GUS[{_uspf}{_uswt}{d.Item2.Naam}] = CIF_GUS[{_uspf}{_uswt}{d.Item2.Naam}] && !(IH[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] && Knipper_1Hz) || G[{_fcpf}{d.Item1.Naam}] && D[{_dpf}{d.Item2.Naam}] && IH[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] && Knipper_1Hz || EH[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] && A[{_fcpf}{d.Item1.Naam}] && !G[{_fcpf}{d.Item1.Naam}];");
                     }
                     break;
             }


### PR DESCRIPTION
Wanneer de schoolingreep actief is, gaat het wachtlicht knipperen zolang de drukknop ingedrukt blijft.
De schoolingreep kan voortijdig afvallen, wanneer de drukknop wordt losgelaten terwijl het op dat moment nog niet groen is (H[{_hpf}{_hschoolingreep}{_dpf}{d.Item2.Naam}] valt dan af). De aanvraag blijft dan logischerwijs staan.
Als op het moment van het afvallen van de schoolingreep het wachtlicht in zijn knippercyclus gedoofd is, wordt het daarna niet meer ontstoken. Het wachtlicht blijft dan gedoofd terwijl er wel nog een aanvraag staat.

Deze PR voegt toe dat het wachtlicht weer opgezet wordt op EH van de schoolingreep zolang de signaalgroep niet groen is. De aanvullende toets op het hebben van een aanvraag op de signaalgroep is mogelijk overbodig, maar lijkt mij zinvol om erbij te hebben voor het geval de aanvraag gelijktijdig door iets anders wordt teruggenomen.