### PR TITLE
Fix fixatie bij multi ML-molens

### DIFF
--- a/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Sources/CCOLGeneratorGenerateRegC.cs
+++ b/TLCGen.PluggedInItems/TLCGen.Generators.CCOL/CodeGeneration/Sources/CCOLGeneratorGenerateRegC.cs
@@ -923,7 +923,7 @@ namespace TLCGen.Generators.CCOL.CodeGeneration
                 }
                 else
                 {
-                    foreach(var r in c.MultiModuleMolens)
+                    foreach (var r in c.MultiModuleMolens.Where(x => x.Modules.Any(x2 => x2.Fasen.Any())))
                     {
                         sb.AppendLine($"{ts}Fixatie({_ispf}{_isfix}, 0, FCMAX-1, SCH[{_schpf}{_schbmfix}], IH[{_hpf}{_hfixatietegenh}], PR{r.Reeks}, {r.Reeks});");
                     }

--- a/TLCGen.Setup/TLCGen.Setup.wixproj
+++ b/TLCGen.Setup/TLCGen.Setup.wixproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="WixToolset.Sdk/6.0.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="WixToolset.Sdk/6.0.0" ToolsVersion="4.0">
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>Debug</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
@@ -19,7 +19,7 @@
     <Content Include="license.rtf" />
   </ItemGroup>
   <ItemGroup>
-	  <PackageReference Include="WixToolset.UI.wixext" Version="6.0.0" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="6.0.0" />
   </ItemGroup>
   <Import Project="..\.paket\Paket.Restore.targets" />
 </Project>


### PR DESCRIPTION
Zeer 'minor issue', maar ook erg eenvoudige oplossing.
Check op aanwezigheid van fasen bij gebruik van meerdere modulemolens. Relevant tijdens de ontwerpfase wanneer je een deel van de regeling (met MLA) wil compileren en van het andere deel (MLB) de ML molen nog niet gevuld is.